### PR TITLE
PageTitle plugin compatibility and better handling of exclusions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,21 @@
+.gitattributes export-ignore
+.gitignore     export-ignore
+README.md      export-ignore
+
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Custom for Visual Studio
+*.cs     diff=csharp
+
+# Standard to msysgit
+*.doc	 diff=astextplain
+*.DOC	 diff=astextplain
+*.docx diff=astextplain
+*.DOCX diff=astextplain
+*.dot  diff=astextplain
+*.DOT  diff=astextplain
+*.pdf  diff=astextplain
+*.PDF	 diff=astextplain
+*.rtf	 diff=astextplain
+*.RTF	 diff=astextplain

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,43 @@
+# Windows image file caches
+Thumbs.db
+ehthumbs.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# =========================
+# Operating System Files
+# =========================
+
+# OSX
+# =========================
+
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Thumbnails
+._*
+
+# Files that might appear on external disk
+.Spotlight-V100
+.Trashes
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk

--- a/README
+++ b/README
@@ -13,7 +13,7 @@ Please refer to http://www.dokuwiki.org/plugins for additional info
 on how to install plugins in DokuWiki.
 
 ----
-Copyright (C) Håkan Sandell <sandell.hakan@gmail.com>
+Copyright (C) HÃ¥kan Sandell <sandell.hakan@gmail.com>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/action.php
+++ b/action.php
@@ -3,7 +3,7 @@
  * DokuWiki Plugin twistienav (Action Component)
  *
  * @license GPL 2 http://www.gnu.org/licenses/gpl-2.0.html
- * @author  Håkan Sandell <sandell.hakan@gmail.com>
+ * @author  HÃ¥kan Sandell <sandell.hakan@gmail.com>
  * @maintainer: Simon Delage <simon.geekitude@gmail.com>
  */
 
@@ -196,3 +196,4 @@ class action_plugin_twistienav extends DokuWiki_Action_Plugin {
         }
     }
 }
+// vim: set fileencoding=utf-8 expandtab ts=4 sw=4 :

--- a/script.js
+++ b/script.js
@@ -11,7 +11,7 @@ var twistienav_plugin = {
 
     init: function () {
 		var $match = 0;
-        if ((JSINFO['conf']['breadcrumbs'] >= 1) && (jQuery('div.youarehere').length !== 0)) {
+        if ((JSINFO['conf']['breadcrumbs'] > 0) && (jQuery('div.youarehere').length !== 0)) {
             twistienav_plugin.breadcrumbs('div.youarehere', 'yah_ns');
 			$match++;
         }
@@ -20,7 +20,7 @@ var twistienav_plugin = {
 			$match++;
         }
         if ($match == 0) {
-			if ((JSINFO['conf']['breadcrumbs'] >= 1) && (jQuery('div.breadcrumbs:has("span.bcsep")').length !== 0)) {
+			if ((JSINFO['conf']['breadcrumbs'] > 0) && (jQuery('div.breadcrumbs:has("span.bcsep")').length !== 0)) {
 				twistienav_plugin.breadcrumbs('div.breadcrumbs:has("span.bcsep")', 'bc_ns');
 			}
 			if ((JSINFO['conf']['youarehere'] == 1) && (jQuery('div.breadcrumbs:not(:has("span.bcsep"))').length !== 0)) {

--- a/script.js
+++ b/script.js
@@ -2,7 +2,7 @@
  * AJAX functions for the pagename quicksearch
  *
  * @license  GPL2 (http://www.gnu.org/licenses/gpl.html)
- * @author   Håkan Sandell <sandell.hakan@gmail.com>
+ * @author   HÃ¥kan Sandell <sandell.hakan@gmail.com>
  */
 
 var twistienav_plugin = {
@@ -206,3 +206,4 @@ var twistienav_plugin = {
 jQuery(function () {
     twistienav_plugin.init();
 });
+// vim: set fileencoding=utf-8 expandtab ts=4 sw=4 :

--- a/style.less
+++ b/style.less
@@ -1,7 +1,7 @@
 /** 
  * Stylesheet for TwistieNav plugin
  *
- * @author Håkan Sandell <sandell.hakan@gmail.com>
+ * @author HÃ¥kan Sandell <sandell.hakan@gmail.com>
  */
 .dokuwiki div.breadcrumbs span.twistienav_twistie:before,
 .dokuwiki div.breadcrumbs span.twistienav_map:before,
@@ -104,3 +104,4 @@ div#twistienav__popup ul li {
 div#twistienav__popup ul li a.twistienav_ns {
   font-weight: bold;
 }
+// vim: set fileencoding=utf-8 expandtab ts=4 sw=4 :


### PR DESCRIPTION
This PR will improve compatibility with PageTitle plugin which provides similar syntax of croissant plugin for (trace and hierarchical) breadcrumbs title. Known plugins that set title and its metadata keys are mapped in the class property *title_metadata*. The availability of those plugins are checked in the constructor.

This PR also includes better handling of exclusions config parameter, that is converted to array in the constructor and be stored in the dedicated class property. This eliminate using global excluded variables.

