### PR TITLE
Add useheading config back

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -11,3 +11,4 @@ $conf['twistieMap']         = 1;
 $conf['pageIdTrace']        = 1;
 $conf['pageIdExtraTwistie'] = 1;
 $conf['style']              = 'svg';
+$conf['useheading']         = 1;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -11,3 +11,4 @@ $meta['twistieMap']         = array('onoff');
 $meta['pageIdTrace']        = array('onoff');
 $meta['pageIdExtraTwistie'] = array('onoff');
 $meta['style']              = array('multichoice', '_choices' => array('svg','fa'));
+$meta['useheading']         = array('onoff');

--- a/helper.php
+++ b/helper.php
@@ -107,9 +107,12 @@ class helper_plugin_twistienav extends DokuWiki_Plugin {
                     $classes .= "wikilink2";
                 }
                 // Get page title from metadata
-                foreach ($this->title_metadata as $plugin => $pluginkey) {
-                    $title = p_get_metadata($target, $pluginkey, METADATA_DONT_RENDER);
-                    if ($title != null) break;
+                $title = null;
+                if ($this->getConf('useheading')) {
+                    foreach ($this->title_metadata as $plugin => $pluginkey) {
+                        $title = p_get_metadata($target, $pluginkey, METADATA_DONT_RENDER);
+                        if ($title != null) break;
+                    }
                 }
                 $data[$datakey]['id'] = $target;
                 $title = @$title ?: hsc(noNS($item['id']));

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -11,3 +11,4 @@ $lang['twistieMap']         = 'Use map glyph for TwistieNavs showing wiki home i
 $lang['pageIdTrace']        = 'Look for a [<code>pageId</code>] element and try to turn it into a short hierarchical trace with TwistieNavs.';
 $lang['pageIdExtraTwistie'] = 'Attempt to add an extra TwistieNav after [<code>pageId</code>] element that will show a popup with global index.';
 $lang['style']              = 'Use SVG images or Font Awesome glyphs. Font Awesome has to be externally installed (by the template or another plugin).';
+$lang['useheading']         = 'Use first heading title on wiki pages instead of showing IDs.';


### PR DESCRIPTION
useheading was available in previous releases of twistienav, this brings it back to enable the old behavior of having IDs in the twistienav menu instead of page titles.

This doesn't change the current defaults, this only adds the option to get back the previous defaults.